### PR TITLE
Pragma Fixed

### DIFF
--- a/src/Badges.sol
+++ b/src/Badges.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import { ERC4973 } from "ERC4973/ERC4973.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/src/BadgesV2.sol
+++ b/src/BadgesV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./Badges.sol";
 

--- a/src/Raft.sol
+++ b/src/Raft.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";

--- a/src/RaftV2.sol
+++ b/src/RaftV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./Raft.sol";
 

--- a/src/SpecDataHolder.sol
+++ b/src/SpecDataHolder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import { Raft } from "./Raft.sol";
 import "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";

--- a/src/SpecDataHolderV2.sol
+++ b/src/SpecDataHolderV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./SpecDataHolder.sol";
 


### PR DESCRIPTION
**Floating pragmas are considered a bad practice.**

It is always recommended that `pragma` should be fixed (not floating) to the version that you are intending to deploy your contracts with. 

For more information Check [this](https://www.oreilly.com/library/view/mastering-blockchain-programming/9781839218262/d1250994-b952-4d5e-9cde-1b852c18b55f.xhtml) out

Issue #67 Solved.
I hope that the team and community will appreciate my small contribution to this beautiful project :)

Thanks,
AB Dee.